### PR TITLE
fix: (readme) - Correct argument for useMediaDevices() hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ const constraints: MediaStreamConstraints = {
 };
 
 export const BarcodeScanner = () => {
-  const { devices } = useMediaDevices(constraints);
+  const { devices } = useMediaDevices({ constraints });
   const deviceId = devices?.[0]?.deviceId;
   const { ref } = useZxing({
     paused: !deviceId,


### PR DESCRIPTION
useMediaDevices() hook accepts an object with 'constraints' and 'onError()' as their properties. 